### PR TITLE
Add RegistrationInterface

### DIFF
--- a/src/ECPublicKeyTrait.php
+++ b/src/ECPublicKeyTrait.php
@@ -10,8 +10,19 @@ trait ECPublicKeyTrait
     // Stored base64-encoded
     private $pubKey = '';
 
-    // Binary string of public key
+    /**
+     * @deprecated Methods that return binary values are suffixed with "binary".
+     * @return string Binary string of public key
+     */
     public function getPublicKey(): string
+    {
+        return base64_decode($this->pubKey);
+    }
+
+    /**
+     * @return string The decoded public key.
+     */
+    public function getPublicKeyBinary(): string
     {
         return base64_decode($this->pubKey);
     }

--- a/src/ECPublicKeyTrait.php
+++ b/src/ECPublicKeyTrait.php
@@ -16,6 +16,8 @@ trait ECPublicKeyTrait
      */
     public function getPublicKey(): string
     {
+        trigger_error('Please use getPublicKeyBinary().', E_USER_DEPRECATED);
+
         return base64_decode($this->pubKey);
     }
 

--- a/src/ECPublicKeyTrait.php
+++ b/src/ECPublicKeyTrait.php
@@ -33,7 +33,7 @@ trait ECPublicKeyTrait
     // public key component
     public function getPublicKeyPem(): string
     {
-        $key = $this->getPublicKey();
+        $key = $this->getPublicKeyBinary();
 
         // Described in RFC 5480
         // Just use an OID calculator to figure out *that* encoding

--- a/src/Registration.php
+++ b/src/Registration.php
@@ -5,7 +5,7 @@ namespace Firehed\U2F;
 
 use OutOfBoundsException;
 
-class Registration
+class Registration implements RegistrationInterface
 {
     use AttestationCertificateTrait;
     use ECPublicKeyTrait;

--- a/src/RegistrationInterface.php
+++ b/src/RegistrationInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Firehed\U2F;
+
+use Serializable;
+
+/**
+ * A U2F registration.
+ */
+interface RegistrationInterface
+{
+    /**
+     * @return string The decoded attestation of the U2F token.
+     */
+    public function getAttestationCertificateBinary(): string;
+
+    /**
+     * @return int The counter of the U2F registration.
+     */
+    public function getCounter(): int;
+
+    /**
+     * @return string The decoded key handle of the U2F registration.
+     */
+    public function getKeyHandleBinary(): string;
+
+    /**
+     * @return string The decoded public key of the U2F
+     * registration.
+     */
+    public function getPublicKeyBinary(): string;
+}

--- a/src/RegistrationInterface.php
+++ b/src/RegistrationInterface.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Firehed\U2F;
 
-use Serializable;
-
 /**
  * A U2F registration.
  */

--- a/src/Server.php
+++ b/src/Server.php
@@ -50,23 +50,23 @@ class Server
 
     /**
      * This method authenticates a `SignResponse` against outstanding
-     * `Registrations` and their corresponding `SignRequest`s. If the
-     * response's signature validates and the counter hasn't done anything
-     * strange, the Registration will be returned with an updated counter
-     * value, which *must* be persisted for the next authentication. If any
-     * verification component fails, a `SE` will be thrown.
+     * registrations and their corresponding `SignRequest`s. If the response's
+     * signature validates and the counter hasn't done anything strange, the
+     * registration will be returned with an updated counter value, which *must*
+     * be persisted for the next authentication. If any verification component
+     * fails, a `SE` will be thrown.
      *
      * @param SignResponse $response the parsed response from the user
-     * @return Registration if authentication succeeds
+     * @return RegistrationInterface if authentication succeeds
      * @throws SE if authentication fails
      * @throws BadMethodCallException if a precondition is not met
      */
-    public function authenticate(SignResponse $response): Registration
+    public function authenticate(SignResponse $response): RegistrationInterface
     {
         if (!$this->registrations) {
             throw new BadMethodCallException(
-                'Before calling authenticate(), provide `Registration`s with '.
-                'setRegistrations()'
+                'Before calling authenticate(), provide objects implementing'.
+                'RegistrationInterface with setRegistrations()'
             );
         }
         if (!$this->signRequests) {
@@ -179,15 +179,15 @@ class Server
     /**
      * This method authenticates a RegisterResponse against its corresponding
      * RegisterRequest by verifying the certificate and signature. If valid, it
-     * returns a Registration object; if not, a SE will be
-     * thrown and attempt to register the key must be aborted.
+     * returns a registration; if not, a SE will be thrown and attempt to
+     * register the key must be aborted.
      *
      * @param RegisterResponse $resp The response to verify
-     * @return Registration if the response is proven authentic
+     * @return RegistrationInterface if the response is proven authentic
      * @throws SE if the response cannot be proven authentic
      * @throws BadMethodCallException if a precondition is not met
      */
-    public function register(RegisterResponse $resp): Registration
+    public function register(RegisterResponse $resp): RegistrationInterface
     {
         if (!$this->registerRequest) {
             throw new BadMethodCallException(
@@ -278,9 +278,10 @@ class Server
     }
 
     /**
-     * Provide a user's existing Registrations to be used during authentication
+     * Provide a user's existing registration to be used during
+     * authentication
      *
-     * @param Registration[] $registrations
+     * @param RegistrationInterface[] $registrations
      * @return self
      */
     public function setRegistrations(array $registrations): self
@@ -321,13 +322,13 @@ class Server
     }
 
     /**
-     * Creates a new SignRequest for an existing Registration for an
+     * Creates a new SignRequest for an existing registration for an
      * authenticating user, used by the `u2f.sign` API.
      *
-     * @param Registration $reg one of the user's existing Registrations
+     * @param RegistrationInterface $reg one of the user's existing Registrations
      * @return SignRequest
      */
-    public function generateSignRequest(Registration $reg): SignRequest
+    public function generateSignRequest(RegistrationInterface $reg): SignRequest
     {
         return (new SignRequest())
             ->setAppId($this->getAppId())
@@ -336,9 +337,9 @@ class Server
     }
 
     /**
-     * Wraps generateSignRequest for multiple Registrations
+     * Wraps generateSignRequest for multiple registrations
      *
-     * @param Registration[] $registrations
+     * @param RegistrationInterface[] $registrations
      * @return SignRequest[]
      */
     public function generateSignRequests(array $registrations): array

--- a/src/Server.php
+++ b/src/Server.php
@@ -172,7 +172,7 @@ class Server
         return (new Registration())
             ->setAttestationCertificate($registration->getAttestationCertificateBinary())
             ->setKeyHandle($registration->getKeyHandleBinary())
-            ->setPublicKey($registration->getPublicKey())
+            ->setPublicKey($registration->getPublicKeyBinary())
             ->setCounter($response->getCounter());
     }
 
@@ -205,7 +205,7 @@ class Server
             $this->registerRequest->getApplicationParameter(),
             $resp->getClientData()->getChallengeParameter(),
             $resp->getKeyHandleBinary(),
-            $resp->getPublicKey()
+            $resp->getPublicKeyBinary()
         );
 
         $pem = $resp->getAttestationCertificatePem();
@@ -228,7 +228,7 @@ class Server
             ->setAttestationCertificate($resp->getAttestationCertificateBinary())
             ->setCounter(0) // The response does not include this
             ->setKeyHandle($resp->getKeyHandleBinary())
-            ->setPublicKey($resp->getPublicKey());
+            ->setPublicKey($resp->getPublicKeyBinary());
     }
 
     /**

--- a/tests/ECPublicKeyTraitTest.php
+++ b/tests/ECPublicKeyTraitTest.php
@@ -28,7 +28,7 @@ class ECPublicKeyTraitTest extends \PHPUnit\Framework\TestCase
         );
         $this->assertSame(
             $key,
-            $obj->getPublicKey(),
+            $obj->getPublicKeyBinary(),
             'getPublicKey should return the set value'
         );
     }

--- a/tests/RegisterResponseTest.php
+++ b/tests/RegisterResponseTest.php
@@ -117,7 +117,7 @@ class RegisterResponseTest extends \PHPUnit\Framework\TestCase
 
         $this->assertSame(
             $pubkey,
-            $response->getPublicKey(),
+            $response->getPublicKeyBinary(),
             'Public key was not parsed correctly'
         );
         $this->assertSame(

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -223,8 +223,8 @@ class ServerTest extends \PHPUnit\Framework\TestCase
         );
 
         $this->assertSame(
-            $response->getPublicKey(),
-            $registration->getPublicKey(),
+            $response->getPublicKeyBinary(),
+            $registration->getPublicKeyBinary(),
             'Public key was not copied from response'
         );
     }

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -200,7 +200,7 @@ class ServerTest extends \PHPUnit\Framework\TestCase
             ->setRegisterRequest($request)
             ->register($response);
         $this->assertInstanceOf(
-            Registration::class,
+            RegistrationInterface::class,
             $registration,
             'Server->register did not return a registration'
         );
@@ -311,7 +311,7 @@ class ServerTest extends \PHPUnit\Framework\TestCase
             }
             throw $e;
         }
-        $this->assertInstanceOf(Registration::class, $reg);
+        $this->assertInstanceOf(RegistrationInterface::class, $reg);
     }
 
     /**
@@ -455,19 +455,21 @@ class ServerTest extends \PHPUnit\Framework\TestCase
                 ->setSignRequests([$request])
                 ->authenticate($response);
         $this->assertInstanceOf(
-            Registration::class,
+            RegistrationInterface::class,
             $return,
-            'A successful authentication should have returned a Registration'
+            'A successful authentication should have returned an object '.
+            'implementing RegistrationInterface'
         );
         $this->assertNotSame(
             $registration,
             $return,
-            'A new instance of Registration should have been returned'
+            'A new object implementing RegistrationInterface should have been '.
+            'returned'
         );
         $this->assertSame(
             $response->getCounter(),
             $return->getCounter(),
-            'The new Registration\'s counter did not match the Response'
+            'The new registration\'s counter did not match the Response'
         );
     }
 
@@ -684,7 +686,7 @@ class ServerTest extends \PHPUnit\Framework\TestCase
             ;
     }
 
-    private function getDefaultRegistration(): Registration
+    private function getDefaultRegistration(): RegistrationInterface
     {
         // From database attached to the authenticating user
         return  (new Registration())


### PR DESCRIPTION
This is a very simple pull request. I've only added an interface for Registration. This, at least in my case, was the class that needed an interface with the highest priority (since it is the object persisted in the database).

Interfaces should be added to the other classes of the library as well. I'm just wondering if it's worth the effort right now considering the new WebAuthn API coming up soon. It might just be better to wait for the new API to be finalised. I believe I read in the WebAuthn API that registrations made with the new API will not be backward compatible, and that they had an additional field (maybe credential id), maybe it was a mechanism for the user agent to prevent the user to register the same U2F device twice…

I wasn't sure if the interface should return the binary or non-binary versions of the strings. However, since ECPublicKeyTrait already has a getPublicKey() which returns a binary value, I was obliged to make the interface return binary value, and I added a new method getPublicKeyBinary() just for consistency with the rest (in the rest of the code, a method that returns a binary value is suffixed with Binary, but not getPublicKey ECPublicKeyTrait).

Also, maybe the quality of the code could be improved with a tool such as PHP CS Fixer to enforce a specific coding style and standards. In particular, it can check that `declare(strict_types=1); `is at the beginning of every file. I saw this statement was on some files but not on others. Also, some functions do not have a return type. Finally, you might want to take a look at Extremely Defensive PHP. It's a set of coding guidelines, you might not agree with them though! :P 