### PR TITLE
[WIP] Webauthn support

### DIFF
--- a/demo/bootstrap.php
+++ b/demo/bootstrap.php
@@ -1,8 +1,24 @@
 <?php
+declare(strict_types=1);
+namespace Firehed\U2F;
+
 chdir(dirname(__DIR__));
 require 'vendor/autoload.php';
 
-$server = new Firehed\U2F\Server();
+function log($data, string $label = '')
+{
+    if ($label) {
+        error_log($label);
+    }
+    error_log(print_r($data, true));
+}
+
+function unbyte(array $bytes): string
+{
+    return implode('', array_map('chr', $bytes));
+}
+
+$server = new Server();
 $server->setAppId('localhost');
 $server->setTrustedCAs([
     'CACerts/yubico.pem',

--- a/demo/bootstrap.php
+++ b/demo/bootstrap.php
@@ -1,0 +1,10 @@
+<?php
+chdir(dirname(__DIR__));
+require 'vendor/autoload.php';
+
+$server = new Firehed\U2F\Server();
+$server->setAppId('localhost');
+$server->setTrustedCAs([
+    'CACerts/yubico.pem',
+]);
+return $server;

--- a/demo/getLoginChallenge.php
+++ b/demo/getLoginChallenge.php
@@ -1,0 +1,17 @@
+<?php
+$server = require 'bootstrap.php';
+
+session_start();
+if (!isset($_SESSION['user_registrations'])) {
+    throw new \Exception('not registered?');
+}
+$regs = $_SESSION['user_registrations'];
+
+// FIXME: each of these sign requests include a different challenge, which is
+// fundamentally incompatbile with webauthn
+$signRequests = $server->generateSignRequests($regs);
+$_SESSION['sign_requests'] = $signRequests;
+
+header('Content-type: application/json');
+
+echo json_encode($signRequests);

--- a/demo/getRegisterChallenge.php
+++ b/demo/getRegisterChallenge.php
@@ -1,0 +1,12 @@
+<?php
+$server = require 'bootstrap.php';
+
+session_start();
+if (!isset($_SESSION['register_challenge'])) {
+    $_SESSION['register_challenge'] = $server->generateRegisterRequest();
+}
+
+header('Content-type: application/json');
+$challenge = $_SESSION['register_challenge']->getChallenge();
+
+echo json_encode($challenge);

--- a/demo/index.css
+++ b/demo/index.css
@@ -1,0 +1,5 @@
+#log {
+    font-family: monospace;
+    width: 80em;
+    height: 25em;
+}

--- a/demo/index.js
+++ b/demo/index.js
@@ -1,0 +1,121 @@
+const log = (str) => {
+  console.log(str)
+
+  if (typeof str === 'object') {
+    str = JSON.stringify(str)
+  }
+  document.getElementById("log").value += str + "\n\n";
+
+}
+
+const getChallenge = async () => {
+  const response = await fetch('/getRegisterChallenge.php')
+  const challenge = await response.json()
+  log("Challenge from server")
+  log(challenge)
+  return challenge
+}
+
+const getCreationOptions = async () => {
+  const userId = "UZSL85T9AFC"
+  const challenge = await getChallenge()
+
+  return {
+    rp: {
+      name: "Duo Security",
+      // id: "duosecurity.com",
+    },
+    user: {
+      id: Uint8Array.from(userId, c => c.charCodeAt(0)),
+      name: "lee@webauthn.guide",
+      displayName: "Lee",
+    },
+
+    challenge: Uint8Array.from(challenge, c => c.charCodeAt(0)),
+    pubKeyCredParams: [{alg: -7, type: "public-key"}],
+
+    timeout: 60000,
+    // excludeCredentials
+    authenticatorSelection: {
+      authenticatorAttachment: "cross-platform",
+      userVerification: "preferred",
+    },
+    attestation: "direct"
+  }
+}
+
+const arrayBuffertoBinaryString = (arrayBuffer) => {
+  const bytes = new Uint8Array(arrayBuffer)
+  let bin = ''
+  const len = bytes.byteLength
+  for (let i = 0; i < len; i++) {
+    bin += String.fromCharCode(bytes[i])
+  }
+  return bin
+}
+
+
+const sendRegistration = async (publicKeyCredential) => {
+  const utf8Decoder = new TextDecoder('utf-8');
+  const decodedClientData = utf8Decoder.decode(publicKeyCredential.response.clientDataJSON)
+  // log("client data json")
+  // log(decodedClientData)
+
+  // const decodedAttestationObj = utf8Decoder.decode(publicKeyCredential.response.attestationObject)
+  const decodedAttestationObj = new Uint8Array(publicKeyCredential.response.attestationObject)
+  log("attestationObject CBOR")
+  log(CBOR.decode(publicKeyCredential.response.attestationObject))
+  // log(decodedAttestationObj)
+  // function buf2hex(buffer) { // buffer is an ArrayBuffer
+  //   return Array.prototype.map.call(new Uint8Array(buffer), x => ('00' + x.toString(16)).slice(-2)).join('');
+  // }
+  // log(buf2hex(publicKeyCredential.response.attestationObject))
+
+  const dataToSend = {
+    id: publicKeyCredential.id,
+    rawId: new Uint8Array(publicKeyCredential.rawId),
+    type: publicKeyCredential.type,
+    clientDataJson: decodedClientData,
+    attestationObjectByteArray: new Uint8Array(publicKeyCredential.response.attestationObject),
+    // attestationObjectCbor: cborBlob,
+  }
+  log("will POST dataToSend")
+  log(dataToSend)
+
+  const response = await fetch('/verifyRegisterChallenge.php', {
+    method: 'POST',
+    credentials: 'same-origin',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    mode: 'no-cors',
+    body: JSON.stringify(dataToSend),
+  })
+
+  const respJson = await response.json()
+
+  log(respJson)
+  // const clientDataObj = JSON.parse(decodedClientData);
+  // log("Client data obj")
+  // log(clientDataObj)
+
+}
+
+const register = async () => {
+  const publicKeyCredentialCreationOptions = await getCreationOptions()
+  log("PK Creation Options")
+  log(publicKeyCredentialCreationOptions)
+
+  const credential = await navigator.credentials.create({
+    publicKey: publicKeyCredentialCreationOptions
+  });
+
+  log("Credential")
+  log(credential)
+
+  let serverRes = await sendRegistration(credential)
+
+}
+
+
+register()

--- a/demo/index.php
+++ b/demo/index.php
@@ -11,7 +11,6 @@
 
 
         <textarea id="log" autocomplete="off"></textarea>
-        <script src="cbor.js" type="text/javascript"></script>
         <script src="index.js" type="text/javascript"></script>
     </body>
 </html>

--- a/demo/index.php
+++ b/demo/index.php
@@ -1,0 +1,17 @@
+<?php
+
+?>
+<html>
+    <head>
+        <title>U2F Demo - WebAuthn</title>
+        <link rel="stylesheet" href="index.css" />
+    </head>
+
+    <body>
+
+
+        <textarea id="log" autocomplete="off"></textarea>
+        <script src="cbor.js" type="text/javascript"></script>
+        <script src="index.js" type="text/javascript"></script>
+    </body>
+</html>

--- a/demo/verifyLoginChallenge.php
+++ b/demo/verifyLoginChallenge.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+namespace Firehed\U2F;
+
+$server = require 'bootstrap.php';
+
+session_start();
+
+if (!isset($_SESSION['user_registrations'])) {
+    throw new Exception('no registrations in session');
+}
+
+$regs = $_SESSION['user_registrations'];
+$server->setRegistrations($regs);
+
+if (!isset($_SESSION['sign_requests'])) {
+    throw new Exception('no registrations in session');
+}
+$signReqs = $_SESSION['sign_requests'];
+unset($_SESSION['sign_requests']);
+$server->setSignRequests($signReqs);
+
+// This expects a (roughly) straight JSONified PublicKeyCredential
+$input = trim(file_get_contents('php://input'));
+log($input, 'raw json');
+$data = json_decode($input, true, 512, JSON_THROW_ON_ERROR);
+
+// parse response
+$response = new \Firehed\U2F\SignResponse();
+
+$cdj = unbyte($data['response']['clientDataJSON']);
+$sig = unbyte($data['response']['signature']);
+$rawAd = unbyte($data['response']['authenticatorData']);
+
+assert(strlen($rawAd) >= 37);
+$rpidHash = substr($rawAd, 0, 32);
+log(bin2hex($rpidHash), 'rpid hash');
+$flags = ord(substr($rawAd, 32, 1));
+$UP = ($flags & 0x01) === 0x01;
+$UV = ($flags & 0x04) === 0x04;
+$AT = ($flags & 0x40) === 0x40;
+$ED = ($flags & 0x80) === 0x80;
+$signCounter = unpack('N', substr($rawAd, 33, 4))[1];
+
+$response->setKeyHandle(unbyte($data['rawId']));
+$response->setCounter($signCounter);
+$response->setUserPresenceByte($UP ? 1 : 0);
+$response->setClientData(WebAuthnClientData::fromJson($cdj));
+$response->setSignature($sig);
+
+log($response);
+
+
+$updatedRegistration = $server->authenticate($response);
+header('Content-type: application/json');
+echo '"not done"';

--- a/demo/verifyLoginChallenge.php
+++ b/demo/verifyLoginChallenge.php
@@ -33,19 +33,10 @@ $cdj = unbyte($data['response']['clientDataJSON']);
 $sig = unbyte($data['response']['signature']);
 $rawAd = unbyte($data['response']['authenticatorData']);
 
-assert(strlen($rawAd) >= 37);
-$rpidHash = substr($rawAd, 0, 32);
-log(bin2hex($rpidHash), 'rpid hash');
-$flags = ord(substr($rawAd, 32, 1));
-$UP = ($flags & 0x01) === 0x01;
-$UV = ($flags & 0x04) === 0x04;
-$AT = ($flags & 0x40) === 0x40;
-$ED = ($flags & 0x80) === 0x80;
-$signCounter = unpack('N', substr($rawAd, 33, 4))[1];
-
+$ad = AuthenticatorData::parse($rawAd);
 $response->setKeyHandle(unbyte($data['rawId']));
-$response->setCounter($signCounter);
-$response->setUserPresenceByte($UP ? 1 : 0);
+$response->setCounter($ad->getSignCount());
+$response->setUserPresenceByte($ad->isUserPresent() ? 1 : 0);
 $response->setClientData(WebAuthnClientData::fromJson($cdj));
 $response->setSignature($sig);
 

--- a/demo/verifyLoginChallenge.php
+++ b/demo/verifyLoginChallenge.php
@@ -26,6 +26,8 @@ $input = trim(file_get_contents('php://input'));
 log($input, 'raw json');
 $data = json_decode($input, true, 512, JSON_THROW_ON_ERROR);
 
+assert($data['type'] === 'public-key');
+
 // parse response
 $response = new \Firehed\U2F\SignResponse();
 
@@ -45,4 +47,4 @@ log($response);
 
 $updatedRegistration = $server->authenticate($response);
 header('Content-type: application/json');
-echo '"not done"';
+echo '"all good?"';

--- a/demo/verifyRegisterChallenge.php
+++ b/demo/verifyRegisterChallenge.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace X;
+namespace Firehed\U2F;
 
 $server = require 'bootstrap.php';
 
@@ -124,11 +124,3 @@ echo json_encode([
     'pk_pem' => $registration->getPublicKeyPem(),
     'ac_pem' => $registration->getAttestationCertificatePem(),
 ]);
-
-function log($data, string $label = '')
-{
-    if ($label) {
-        error_log($label);
-    }
-    error_log(print_r($data, true));
-}

--- a/demo/verifyRegisterChallenge.php
+++ b/demo/verifyRegisterChallenge.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace X;
+
+$server = require 'bootstrap.php';
+
+session_start();
+if (!isset($_SESSION['register_challenge'])) {
+    throw new Exception('no challenge in session');
+}
+
+$registerRequest = $_SESSION['register_challenge'];
+
+$server->setRegisterRequest($registerRequest);
+
+
+$data = json_decode(trim(file_get_contents('php://input')), true);
+// log($data, 'decoded POST');
+// {
+//   id: string  (b64-web?)
+//   rawId: byteArray
+//   type: "public-key"
+//   clientDataJson: jsonString: {
+//     challenge: string
+//     clientExtensions: {},
+//     hashAlgorithm: "SHA-256",
+//     origin: "http://localhost:8080"
+//     type: "webauthn.create"
+//  }
+//  attestationObjectByteArray: cbor-byte-array: {
+//    authData: binString
+//    fmt: "fido-u2f",
+//    attStmt: {
+//      sig: binString
+//      x5c: binString
+//    }
+//  }
+// }
+
+assert($data['type'] === 'public-key');
+
+$aoCBOR = $data['attestationObjectByteArray'];
+// log(bin2hex($aoCBOR), 'cbor bin');
+$ao = (new \Firehed\U2F\CBOR\Decoder())->decodeFromByteArray($aoCBOR);
+log($ao, 'attestion object decoded');
+
+// webAuthn 6.1
+function decodeAuthenticatorData(string $bytes)
+{
+    $i = 0;
+    $read = function ($count) use (&$i, $bytes) {
+        $ret = substr($bytes, $i, $count);
+        $i += $count;
+        return $ret;
+    };
+    assert(strlen($bytes) >= 37);
+    $rpidHash = $read(32);
+    // FIXME: validate this hash_equals origin
+    log(bin2hex($rpidHash), 'rpid hash hex');
+    $flags = ord($read(1));
+    $signCount = $read(4); // todo: unpack(N)
+    log($flags, 'flags');
+    $includedAT = ($flags & 0b01000000) > 0;
+    $includedED = ($flags & 0b10000000) > 0;
+
+    if ($includedAT) {
+        log('AT included');
+        $aaguid = $read(16);
+        $credentialIdLength = $read(2);
+        $credentialIdLength = (ord($credentialIdLength[0]) << 8) + ord($credentialIdLength[1]);
+        $credentialId = $read($credentialIdLength); // FIXME: overflow risk
+        log($credentialId, 'credentialId');
+
+        $restOfData = $read(strlen($bytes) - $i);
+        $publicKey = (new \Firehed\U2F\CBOR\Decoder())->decode($restOfData);
+        log($publicKey, 'pk');
+/*
+    [attest:Firehed\U2F\RegisterResponse:private] =>
+    [pubKey:Firehed\U2F\RegisterResponse:private] =>
+    [clientData:Firehed\U2F\RegisterResponse:private] =>
+    [signature:Firehed\U2F\RegisterResponse:private] =>
+    [keyHandle:Firehed\U2F\RegisterResponse:private] =>
+ */
+    }
+    $response = new \Firehed\U2F\RegisterResponse();
+    $response->setKeyHandle($credentialId);
+    $response->setPublicKey(sprintf('%s%s%s', "\x04", $publicKey[-2], $publicKey[-3]));
+
+    return $response;
+}
+
+// log($authData, 'auth data');
+$authData = $ao['authData'];
+$response = decodeAuthenticatorData($authData);
+log($ao['attStmt'], 'attestation statement');
+$response->setSignature($ao['attStmt']['sig']);
+
+// $keyHandle = implode('', array_map('chr', $data['rawId']));
+// $response->setKeyHandle($keyHandle);
+
+assert(count($ao['attStmt']['x5c']) === 1); // 8.6 verification
+$x5c = $ao['attStmt']['x5c'][0];
+log($x5c);
+$response->setAttestationCertificate($x5c);
+
+$decClientData = json_decode($data['clientDataJson'], true, 512, \JSON_THROW_ON_ERROR);
+
+$clientData = \Firehed\U2F\WebAuthnClientData::fromJson($data['clientDataJson']);
+// $clientData = new \Firehed\U2F\ClientData();
+// $base64WebEncodedChallenge = $decClientData['challenge'];
+// $clientData->setChallenge(\Firehed\U2F\fromBase64Web($base64WebEncodedChallenge));
+$response->setClientData($clientData);
+
+
+log($response, 'register response');
+
+
+
+$registration = $server->register($response);
+header('Content-type: application/json');
+echo json_encode([
+    'counter' => $registration->getCounter(),
+    'khw' => $registration->getKeyHandleWeb(),
+    'pk_pem' => $registration->getPublicKeyPem(),
+    'ac_pem' => $registration->getAttestationCertificatePem(),
+]);
+
+function log($data, string $label = '')
+{
+    if ($label) {
+        error_log($label);
+    }
+    error_log(print_r($data, true));
+}

--- a/src/AuthenticatorData.php
+++ b/src/AuthenticatorData.php
@@ -17,7 +17,9 @@ class AuthenticatorData
     /** @var int */
     private $signCount;
 
+    /** @var ?array Attested Credential Data */
     private $ACD;
+
     private $EXT;
 
     /**
@@ -28,8 +30,7 @@ class AuthenticatorData
     {
         assert(strlen($bytes) >= 37);
 
-        $rpidHash = substr($bytes, 0, 32);
-        log(bin2hex($rpidHash), 'rpid hash');
+        $rpIdHash = substr($bytes, 0, 32);
         $flags = ord(substr($bytes, 32, 1));
         $UP = ($flags & 0x01) === 0x01; // bit 0
         $UV = ($flags & 0x04) === 0x04; // bit 2
@@ -40,7 +41,36 @@ class AuthenticatorData
         $authData = new AuthenticatorData();
         $authData->isUserPresent = $UP;
         $authData->isUserVerified = $UV;
+        $authData->rpIdHash = $rpIdHash;
         $authData->signCount = $signCount;
+
+        $restOfBytes = substr($bytes, 37);
+        $restOfBytesLength = strlen($restOfBytes);
+        if ($AT) {
+            assert($restOfBytesLength >= 18);
+
+            $aaguid = substr($restOfBytes, 0, 16);
+            $credentialIdLength = unpack('n', substr($restOfBytes, 16, 2))[1];
+            assert($restOfBytesLength >= (18 + $credentialIdLength));
+            $credentialId = substr($restOfBytes, 18, $credentialIdLength);
+
+            $rawCredentialPublicKey = substr($restOfBytes, 18 + $credentialIdLength);
+
+            $decoder = new CBOR\Decoder();
+            $credentialPublicKey = $decoder->decode($rawCredentialPublicKey);
+
+            $authData->ACD = [
+                'aaguid' => $aaguid,
+                'credentialId' => $credentialId,
+                'credentialPublicKey' => $credentialPublicKey,
+            ];
+            // var_dump($decoder->getNumberOfBytesRead());
+            // cut rest of bytes down based on that ^ ?
+        }
+        if ($ED) {
+            throw new BadMethodCallException('Not implemented yet');
+        }
+
         return $authData;
     }
 
@@ -49,8 +79,32 @@ class AuthenticatorData
         return $this->isUserPresent;
     }
 
+    public function getAttestedCredentialData(): ?array
+    {
+        return $this->ACD;
+    }
+
     public function getSignCount(): int
     {
         return $this->signCount;
+    }
+
+    public function __debugInfo(): array
+    {
+        $hex = function ($str) {
+            return '0x' . bin2hex($str);
+        };
+        return [
+            'isUserPresent' => $this->isUserPresent,
+            'isUserVerified' => $this->isUserVerified,
+            'rpIdHash' => $hex($this->rpIdHash),
+            'signCount' => $this->signCount,
+            'ACD' => $this->ACD ? [
+                'aaguid' => $hex($this->ACD['aaguid']),
+                'credentialId' => $hex($this->ACD['credentialId']),
+                'credentialPublicKey' => $this->ACD['credentialPublicKey'],
+            ] : null,
+            'EXT' => $this->EXT,
+        ];
     }
 }

--- a/src/AuthenticatorData.php
+++ b/src/AuthenticatorData.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace Firehed\U2F;
+
+class AuthenticatorData
+{
+    /** @var bool */
+    private $isUserPresent;
+
+    /** @var bool */
+    private $isUserVerified;
+
+    /** @var string (binary) */
+    private $rpIdHash;
+
+    /** @var int */
+    private $signCount;
+
+    private $ACD;
+    private $EXT;
+
+    /**
+     * @see https://w3c.github.io/webauthn/#sec-authenticator-data
+     * WebAuthn 6.1
+     */
+    public static function parse(string $bytes): AuthenticatorData
+    {
+        assert(strlen($bytes) >= 37);
+
+        $rpidHash = substr($bytes, 0, 32);
+        log(bin2hex($rpidHash), 'rpid hash');
+        $flags = ord(substr($bytes, 32, 1));
+        $UP = ($flags & 0x01) === 0x01; // bit 0
+        $UV = ($flags & 0x04) === 0x04; // bit 2
+        $AT = ($flags & 0x40) === 0x40; // bit 6
+        $ED = ($flags & 0x80) === 0x80; // bit 7
+        $signCount = unpack('N', substr($bytes, 33, 4))[1];
+
+        $authData = new AuthenticatorData();
+        $authData->isUserPresent = $UP;
+        $authData->isUserVerified = $UV;
+        $authData->signCount = $signCount;
+        return $authData;
+    }
+
+    public function isUserPresent(): bool
+    {
+        return $this->isUserPresent;
+    }
+
+    public function getSignCount(): int
+    {
+        return $this->signCount;
+    }
+}

--- a/src/CBOR/Decoder.php
+++ b/src/CBOR/Decoder.php
@@ -1,0 +1,215 @@
+<?php
+declare(strict_types=1);
+
+namespace Firehed\U2F\CBOR;
+
+use Exception;
+use Psr\Log\LoggerInterface;
+
+class Decoder
+{
+    /** @var LoggerInterface */
+    private $logger;
+
+    const MT_UINT = 0;
+    const MT_NINT = 1;
+    const MT_BYTESTRING = 2;
+    const MT_TEXT = 3;
+    const MT_ARRAY = 4;
+    const MT_MAP = 5;
+    const MT_TAG = 6;
+    const MT_SIMPLE_AND_FLOAT = 7;
+
+    private const NAME_MAP = [
+        'uint',
+        'nint',
+        'bytestr',
+        'textstr',
+        'arr',
+        'map',
+        'tag',
+        'fp/simple',
+    ];
+
+    private $cbor = '';
+    private $i = 0;
+
+    public function __construct()
+    {
+        $this->logger = new \Firehed\SimpleLogger\Stdout();
+    }
+
+    public function decode(string $cbor)
+    {
+        $this->logger->debug('Starting new decode');
+        $this->cbor = $cbor;
+        $this->i = 0;
+        return $this->decodeItem();
+    }
+
+    public function decodeFromByteArray(array $bytes)
+    {
+        return $this->decode(implode('', array_map('chr', $bytes)));
+    }
+
+    public function getNumberOfBytesRead(): int
+    {
+        return $this->i;
+    }
+
+    private function decodeItem()
+    {
+        $item = ord($this->read(1));
+        $majorType = ($item & 0b11100000) >> 5;
+        $addtlInfo = ($item & 0b00011111);
+        $tn = self::NAME_MAP[$majorType];
+        $this->logger->debug("Major type {$majorType} ($tn)");
+        switch ($majorType) {
+            case self::MT_UINT:
+                return $this->decodeUnsignedInteger($addtlInfo);
+            case self::MT_NINT:
+                return $this->decodeNegativeInteger($addtlInfo);
+            case self::MT_BYTESTRING:
+                return $this->decodeBinaryString($addtlInfo);
+            case self::MT_TEXT:
+                return $this->decodeText($addtlInfo);
+            case self::MT_ARRAY:
+                return $this->decodeArray($addtlInfo);
+            case self::MT_MAP:
+                return $this->decodeMap($addtlInfo);
+            case self::MT_TAG:
+                return $this->decodeTag($addtlInfo);
+            case self::MT_SIMPLE_AND_FLOAT:
+                return $this->decodeSimple($addtlInfo);
+            default:
+                throw new Exception('Invalid major type');
+        }
+    }
+
+    private function decodeUnsignedInteger(int $info): int
+    {
+        if ($info <= 23) {
+            $this->logger->debug("uint literal $info");
+            return $info;
+        }
+        if ($info === 24) { // 8-bit int
+            $data = ord($this->read(1));
+            $this->logger->debug("uint8 $data");
+            return $data;
+        } elseif ($info === 25) { // 16-bit int
+            $data = unpack('n', $this->read(2))[1];
+            $this->logger->debug("uint16 $data");
+            return $data;
+        } elseif ($info === 26) { // 32-bit int
+            $data = unpack('N', $this->read(4))[1];
+            $this->logger->debug("uint32 $data");
+            return $data;
+        } elseif ($info === 27) { // 64-bit int
+            $data = unpack('J', $this->read(8))[1];
+            $this->logger->debug("uint64 $data");
+            return $data;
+        } else {
+            $this->logger->error("DUI {$info}");
+            throw new OutOfBoundsException();
+        }
+    }
+
+    private function decodeNegativeInteger(int $addtlInfo): int
+    {
+        $uint = $this->decodeUnsignedInteger($addtlInfo);
+        $negative = -1 - $uint;
+        $this->logger->debug("negative int $negative");
+        return $negative;
+    }
+
+    private function decodeBinaryString(int $addtlInfo): string
+    {
+        $length = $this->decodeUnsignedInteger($addtlInfo);
+        $str = $this->read($length);
+        $this->logger->debug("Bin string ($length) '(omitted)'");
+        return $str;
+    }
+
+    private function decodeText(int $addtlInfo): string
+    {
+        $length = $this->decodeUnsignedInteger($addtlInfo);
+        $str = $this->read($length);
+        $this->logger->debug("UTF8 string ($length) '$str'");
+        return $str;
+    }
+
+    private function decodeArray(int $addtlInfo): array
+    {
+        $numItems = $this->decodeUnsignedInteger($addtlInfo);
+        $this->logger->debug("Array of length $numItems");
+        $ret = [];
+        for ($i = 0; $i < $numItems; $i++) {
+            $this->logger->debug("Getting array #$i");
+            $ret[] = $this->decodeItem();
+        }
+        $this->logger->debug('arr loaded');
+        // $this->logger->debug(print_r($ret, true));
+        return $ret;
+    }
+
+    private function decodeMap(int $addtlInfo): array
+    {
+        $numItems = $this->decodeUnsignedInteger($addtlInfo);
+        $this->logger->debug("Map of length $numItems");
+        $ret = [];
+        for ($i = 0; $i < $numItems; $i++) {
+            $this->logger->debug("Get key $i");
+            $key = $this->decodeItem();
+            $this->logger->debug("Get value $i");
+            $ret[$key] = $this->decodeItem();
+            // $this->logger->debug("Map $i {$key}: {$ret[$key]}");
+        }
+        $this->logger->debug('map loaded');
+        // $this->logger->debug(print_r($ret, true));
+        return $ret;
+    }
+
+    private function decodeTag(int $addtlInfo)
+    {
+        $this->logger->debug("  ==>  tag $addtlInfo");
+        $tag = $this->decodeItem();
+        var_dump($tag);
+        return $tag;
+    }
+
+
+    private function read(int $numBytes)
+    {
+        $data = substr($this->cbor, $this->i, $numBytes);
+        $this->i += $numBytes;
+        return $data;
+    }
+
+    private function decodeSimple(int $info)
+    {
+        switch ($info) {
+            case $info <= 19:
+                return unassigned;
+            case 20:
+                return false;
+            case 21:
+                return true;
+            case 22:
+                return null;
+            case 23:
+                return undefined;
+            case 24:
+                throw new \Exception('idk');
+            case 25:
+                return read_two_half_precisoin_float;
+            case 26:
+                return read_four_single_float;
+            case 27:
+                return read_eight_double;
+            case 28: case 29: case 30:
+                return unassigned;
+            case 31:
+                return break_code;
+        }
+    }
+}

--- a/src/CBOR/Stop.php
+++ b/src/CBOR/Stop.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types=1);
+
+namespace Firehed\U2F\CBOR;
+
+use RuntimeException;
+
+/**
+ * This is a clunky workaround for not being able to (nicely) return a sum type
+ * indicating it's time to stop during decoding.
+ */
+class Stop extends RuntimeException
+{
+}

--- a/src/ChallengeTrait.php
+++ b/src/ChallengeTrait.php
@@ -9,7 +9,7 @@ trait ChallengeTrait
     // B64-websafe value (at no point is the binary version used)
     public function getChallenge(): string
     {
-        return ($this->challenge);
+        return $this->challenge;
     }
 
     public function setChallenge(string $challenge): self

--- a/src/ClientData.php
+++ b/src/ClientData.php
@@ -3,16 +3,20 @@ declare(strict_types=1);
 
 namespace Firehed\U2F;
 
-use JsonSerializable;
 use Firehed\U2F\InvalidDataException as IDE;
 
-class ClientData implements JsonSerializable, ChallengeProvider
+class ClientData implements ClientDataInterface
 {
     use ChallengeTrait;
 
     private $cid_pubkey;
     private $origin;
     private $typ;
+
+    public function getApplicationParameter(): string
+    {
+        return hash('sha256', $this->origin, true);
+    }
 
     public static function fromJson(string $json)
     {

--- a/src/ClientDataInterface.php
+++ b/src/ClientDataInterface.php
@@ -1,0 +1,13 @@
+<?php
+declare(strict_types=1);
+
+namespace Firehed\U2F;
+
+use JsonSerializable;
+
+interface ClientDataInterface extends JsonSerializable, ChallengeProvider
+{
+    public function getApplicationParameter(): string;
+
+    public function getChallengeParameter(): string;
+}

--- a/src/RegisterResponse.php
+++ b/src/RegisterResponse.php
@@ -108,4 +108,17 @@ class RegisterResponse
 
         return $this;
     }
+
+    public function getSignedData(): string
+    {
+        // https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-raw-message-formats.html#registration-response-message-success
+        return sprintf(
+            '%s%s%s%s%s',
+            chr(0),
+            $this->getClientData()->getApplicationParameter(),
+            $this->getClientData()->getChallengeParameter(),
+            $this->getKeyHandleBinary(),
+            $this->getPublicKeyBinary()
+        );
+    }
 }

--- a/src/ResponseTrait.php
+++ b/src/ResponseTrait.php
@@ -20,12 +20,17 @@ trait ResponseTrait
         return base64_decode($this->signature);
     }
 
-    public function getClientData(): ClientData
+    public function getClientData(): ClientDataInterface
     {
         return $this->clientData;
     }
 
-    protected function setSignature(string $signature): self
+    public function setClientData(ClientDataInterface $clientData)
+    {
+        $this->clientData = $clientData;
+    }
+
+    public function setSignature(string $signature): self
     {
         $this->signature = base64_encode($signature);
         return $this;

--- a/src/Server.php
+++ b/src/Server.php
@@ -198,16 +198,7 @@ class Server
         $this->validateChallenge($resp->getClientData(), $this->registerRequest);
         // Check the Application Parameter?
 
-        // https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-raw-message-formats.html#registration-response-message-success
-        $signed_data = sprintf(
-            '%s%s%s%s%s',
-            chr(0),
-            $this->registerRequest->getApplicationParameter(),
-            $resp->getClientData()->getChallengeParameter(),
-            $resp->getKeyHandleBinary(),
-            $resp->getPublicKeyBinary()
-        );
-
+        $signed_data = $resp->getSignedData();
         $pem = $resp->getAttestationCertificatePem();
         if ($this->verifyCA) {
             $resp->verifyIssuerAgainstTrustedCAs($this->trustedCAs);

--- a/src/Server.php
+++ b/src/Server.php
@@ -109,20 +109,7 @@ class Server
 
         $pem = $registration->getPublicKeyPem();
 
-        // U2F Spec:
-        // https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-raw-message-formats.html#authentication-response-message-success
-        $to_verify = sprintf(
-            '%s%s%s%s',
-            $request->getApplicationParameter(),
-            chr($response->getUserPresenceByte()),
-            pack('N', $response->getCounter()),
-            // Note: Spec says this should be from the request, but that's not
-            // actually available via the JS API. Because we assert the
-            // challenge *value* from the Client Data matches the trusted one
-            // from the SignRequest and that value is included in the Challenge
-            // Parameter, this is safe unless/until SHA-256 is broken.
-            $response->getClientData()->getChallengeParameter()
-        );
+        $to_verify = $response->getSignedData();
 
         // Signature must validate against
         $sig_check = openssl_verify(

--- a/src/WebAuthnClientData.php
+++ b/src/WebAuthnClientData.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types=1);
+
+namespace Firehed\U2F;
+
+use JsonSerializable;
+
+class WebAuthnClientData implements ClientDataInterface
+{
+    use ChallengeTrait;
+
+    private $json;
+    private $decoded;
+
+    private function __construct()
+    {
+    }
+
+    public static function fromJson(string $json): WebAuthnClientData
+    {
+        $wacd = new self;
+        $wacd->json = $json;
+
+        $wacd->decoded = json_decode($json, true, 512, \JSON_THROW_ON_ERROR);
+        $wacd->setChallenge(fromBase64Web($wacd->decoded['challenge']));
+        return $wacd;
+    }
+
+    public function getApplicationParameter(): string
+    {
+        $origin = $this->decoded['origin'];
+        // TODO: you can go to a higher level domain in a valid way
+        $host = parse_url($origin, PHP_URL_HOST);
+
+        return hash('sha256', $host, true);
+    }
+
+    public function getChallengeParameter(): string
+    {
+        return hash('sha256', $this->json, true);
+    }
+
+    public function jsonSerialize()
+    {
+        return json_decode($this->json, true);
+    }
+}

--- a/tests/CBOR/DecoderTest.php
+++ b/tests/CBOR/DecoderTest.php
@@ -1,0 +1,164 @@
+<?php
+declare(strict_types=1);
+
+namespace Firehed\U2F\CBOR;
+
+use const INF;
+use const NAN;
+
+/**
+ * @coversDefaultClass Firehed\U2F\CBOR\Decoder
+ * @covers ::<protected>
+ * @covers ::<private>
+ */
+class DecoderTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * @covers ::decode
+     * @dataProvider githubTestVectors
+     */
+    public function testDecodeGH(string $cbor, $decoded)
+    {
+        $decoder = new Decoder();
+        $result = $decoder->decode($cbor);
+        $this->assertSame($decoded, $result);
+    }
+    /**
+     * @covers ::decode
+     * @dataProvider rfcExamples
+     */
+    public function testDecodeRFC(string $cbor, $decoded)
+    {
+        $decoder = new Decoder();
+        $result = $decoder->decode($cbor);
+        $this->assertSame($decoded, $result);
+    }
+
+    /**
+     * @see https://github.com/cbor/test-vectors
+     */
+    public function githubTestVectors(): array
+    {
+        $json = file_get_contents(__DIR__ . '/vectors.json');
+        $data = json_decode($json, true);
+        return array_map(function ($row) {
+            return [base64_decode($row['cbor']), $row['decoded']];
+        }, array_filter($data, function ($row) {
+            return isset($row['decoded']);
+        }));
+    }
+
+    /**
+     * @see RFC7049 Appendix A
+     */
+    public function rfcExamples(): array
+    {
+        return array_map(function ($vector) {
+            return [hex2bin($vector[1]), $vector[0]];
+        }, [
+            [0, '00'],
+            [1, '01'],
+            [10, '0a'],
+            [23, '17'],
+            [24, '1818'],
+            [25, '1819'],
+            [100, '1864'],
+            [1000, '1903e8'],
+            [1000000, '1a000f4240'],
+            [1000000000000, '1b000000e8d4a51000'],
+            [18446744073709551615, '1bffffffffffffffff'],
+            [18446744073709551616, 'c249010000000000000000'],
+            [-18446744073709551616, '3bffffffffffffffff'],
+            [-18446744073709551617, 'c349010000000000000000'],
+            [-1, '20'],
+            [-10, '29'],
+            [-100, '3863'],
+            [-1000, '3903e7'],
+            [0.0, 'f90000'],
+            [-0.0, 'f98000'],
+            [1.0, 'f93c00'],
+            [1.1, 'fb3ff199999999999a'],
+            [1.5, 'f93e00'],
+            [65504.0, 'f97bff'],
+            [100000.0, 'fa47c35000'],
+            [3.4028234663852886e+38, 'fa7f7fffff'],
+            [1.0e+300, 'fb7e37e43c8800759c'],
+            [5.960464477539063e-8, 'f90001'],
+            [0.00006103515625, 'f90400'],
+            [-4.0, 'f9c400'],
+            [-4.1, 'fbc010666666666666'],
+            [INF, 'f97c00'],
+            [NAN, 'f97e00'],
+            [-INF, 'f9fc00'],
+            [INF, 'fa7f800000'],
+            [NAN, 'fa7fc00000'],
+            [-INF, 'faff800000'],
+            [INF, 'fb7ff0000000000000'],
+            [NAN, 'fb7ff8000000000000'],
+            [-INF, 'fbfff0000000000000'],
+            [false, 'f4'],
+            [true, 'f5'],
+            [null, 'f6'],
+            // [undefined, 'f7'],
+            // [simple(16), 'f0'],
+            // [simple(24), 'f818'],
+            // [simple(255), 'f8ff'],
+// | 0("2013-03-21T20:04:00Z")    | 0xc074323031332d30332d32315432303a |
+// |                              | 30343a30305a                       |
+            // [1(1363896240), 'c11a514b67b0'],
+            // [1(1363896240.5), 'c1fb41d452d9ec200000'],
+            // [23(h'01020304'), 'd74401020304'],
+            // [24(h'6449455446'), 'd818456449455446'],
+// | 32("http://www.example.com") | 0xd82076687474703a2f2f7777772e6578 |
+// |                              | 616d706c652e636f6d                 |
+            ['', '40'],
+            ["\x01\x02\x03\x04", '4401020304'],
+            ["", '60'],
+            ["a", '6161'],
+            ["IETF", '6449455446'],
+            ["\"\\", '62225c'],
+            ["\u00fc", '62c3bc'],
+            ["\u6c34", '63e6b0b4'],
+            ["\ud800\udd51", '64f0908591'],
+            [[], '80'],
+            [[1, 2, 3], '83010203'],
+            [[1, [2, 3], [4, 5]], '8301820203820405'],
+// | [1, 2, 3, 4, 5, 6, 7, 8, 9,  | 0x98190102030405060708090a0b0c0d0e |
+// | 10, 11, 12, 13, 14, 15, 16,  | 0f101112131415161718181819         |
+// | 17, 18, 19, 20, 21, 22, 23,  |                                    |
+// | 24, 25]                      |                                    |
+            [[], 'a0'],
+            [[1 => 2, 3 => 4], 'a201020304'],
+            // [{"a": 1, "b": [2, 3]}, 'a26161016162820203'],
+            // [["a", {"b": "c"}], '826161a161626163'],
+// | {"a": "A", "b": "B", "c":    | 0xa5616161416162614261636143616461 |
+// | "C", "d": "D", "e": "E"}     | 4461656145                         |
+            // [(_ h'0102', h'030405'), '5f42010243030405ff'],
+            ["streaming", '7f657374726561646d696e67ff'],
+            [[], '9fff'],
+            [[1, [2, 3], [4, 5]], '9f018202039f0405ffff'],
+            [[1, [2, 3], [4, 5]], '9f01820203820405ff'],
+            [[1, [2, 3], [4, 5]], '83018202039f0405ff'],
+            [[1, [2, 3], [4, 5]], '83019f0203ff820405'],
+// | [_ 1, 2, 3, 4, 5, 6, 7, 8,   | 0x9f0102030405060708090a0b0c0d0e0f |
+// | 9, 10, 11, 12, 13, 14, 15,   | 101112131415161718181819ff         |
+// | 16, 17, 18, 19, 20, 21, 22,  |                                    |
+// | 23, 24, 25]                  |                                    |
+            [["a" => 1, "b" => [2, 3]], 'bf61610161629f0203ffff'],
+            [["a", ["b" => "c"]], '826161bf61626163ff'],
+            [["Fun" => true, "Amt" => -2], 'bf6346756ef563416d7421ff'],
+        ]);
+    }
+
+    /**
+     * Uses an example string from RFC7049 2.2.2
+     * @covers ::decode
+     */
+    public function testVariableLengthByteString()
+    {
+        $cbor = hex2bin('5f44aabbccdd43eeff99ff');
+        $decoder = new Decoder();
+        $result = $decoder->decode($cbor);
+        $this->assertSame(hex2bin('aabbccddeeff99'), $result);
+    }
+}

--- a/tests/CBOR/DecoderTest.php
+++ b/tests/CBOR/DecoderTest.php
@@ -16,22 +16,21 @@ class DecoderTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::decode
      * @dataProvider githubTestVectors
-     */
-    public function testDecodeGH(string $cbor, $decoded)
-    {
-        $decoder = new Decoder();
-        $result = $decoder->decode($cbor);
-        $this->assertSame($decoded, $result);
-    }
-    /**
-     * @covers ::decode
+     * @dataProvider rfcBigintExamples
      * @dataProvider rfcExamples
+     * @dataProvider rfcTagExamples
      */
-    public function testDecodeRFC(string $cbor, $decoded)
+    public function testDecode(string $cbor, $expected)
     {
         $decoder = new Decoder();
         $result = $decoder->decode($cbor);
-        $this->assertSame($decoded, $result);
+        if (is_float($expected) && ($expected > \PHP_INT_MAX) || ($expected < \PHP_INT_MIN)) {
+            $this->assertEquals($expected, $result);
+        } elseif (is_float($expected) && is_nan($expected)) {
+            $this->assertTrue(is_nan($result), 'Result should be NAN');
+        } else {
+            $this->assertSame($expected, $result);
+        }
     }
 
     /**
@@ -40,7 +39,7 @@ class DecoderTest extends \PHPUnit\Framework\TestCase
     public function githubTestVectors(): array
     {
         $json = file_get_contents(__DIR__ . '/vectors.json');
-        $data = json_decode($json, true);
+        $data = json_decode($json, true, 512, JSON_THROW_ON_ERROR | JSON_BIGINT_AS_STRING);
         return array_map(function ($row) {
             return [base64_decode($row['cbor']), $row['decoded']];
         }, array_filter($data, function ($row) {
@@ -66,10 +65,6 @@ class DecoderTest extends \PHPUnit\Framework\TestCase
             [1000, '1903e8'],
             [1000000, '1a000f4240'],
             [1000000000000, '1b000000e8d4a51000'],
-            [18446744073709551615, '1bffffffffffffffff'],
-            [18446744073709551616, 'c249010000000000000000'],
-            [-18446744073709551616, '3bffffffffffffffff'],
-            [-18446744073709551617, 'c349010000000000000000'],
             [-1, '20'],
             [-10, '29'],
             [-100, '3863'],
@@ -117,36 +112,55 @@ class DecoderTest extends \PHPUnit\Framework\TestCase
             ["a", '6161'],
             ["IETF", '6449455446'],
             ["\"\\", '62225c'],
-            ["\u00fc", '62c3bc'],
-            ["\u6c34", '63e6b0b4'],
-            ["\ud800\udd51", '64f0908591'],
+            ["\u{00fc}", '62c3bc'],
+            ["\u{6c34}", '63e6b0b4'],
+            ["\u{10151}", '64f0908591'],
             [[], '80'],
             [[1, 2, 3], '83010203'],
             [[1, [2, 3], [4, 5]], '8301820203820405'],
-// | [1, 2, 3, 4, 5, 6, 7, 8, 9,  | 0x98190102030405060708090a0b0c0d0e |
-// | 10, 11, 12, 13, 14, 15, 16,  | 0f101112131415161718181819         |
-// | 17, 18, 19, 20, 21, 22, 23,  |                                    |
-// | 24, 25]                      |                                    |
+            [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25],
+                '98190102030405060708090a0b0c0d0e0f101112131415161718181819'],
             [[], 'a0'],
             [[1 => 2, 3 => 4], 'a201020304'],
-            // [{"a": 1, "b": [2, 3]}, 'a26161016162820203'],
-            // [["a", {"b": "c"}], '826161a161626163'],
-// | {"a": "A", "b": "B", "c":    | 0xa5616161416162614261636143616461 |
-// | "C", "d": "D", "e": "E"}     | 4461656145                         |
-            // [(_ h'0102', h'030405'), '5f42010243030405ff'],
+            [["a" => 1, "b" => [2, 3]], 'a26161016162820203'],
+            [["a", ["b" => "c"]], '826161a161626163'],
+            [["a" => "A", "b" => "B", "c" => "C", "d" => "D", "e" => "E"],
+                'a56161614161626142616361436164614461656145'],
+            ["\x01\x02\x03\x04\x05", '5f42010243030405ff'],
             ["streaming", '7f657374726561646d696e67ff'],
             [[], '9fff'],
             [[1, [2, 3], [4, 5]], '9f018202039f0405ffff'],
             [[1, [2, 3], [4, 5]], '9f01820203820405ff'],
             [[1, [2, 3], [4, 5]], '83018202039f0405ff'],
             [[1, [2, 3], [4, 5]], '83019f0203ff820405'],
-// | [_ 1, 2, 3, 4, 5, 6, 7, 8,   | 0x9f0102030405060708090a0b0c0d0e0f |
-// | 9, 10, 11, 12, 13, 14, 15,   | 101112131415161718181819ff         |
-// | 16, 17, 18, 19, 20, 21, 22,  |                                    |
-// | 23, 24, 25]                  |                                    |
+            [[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25],
+                '9f0102030405060708090a0b0c0d0e0f101112131415161718181819ff'],
             [["a" => 1, "b" => [2, 3]], 'bf61610161629f0203ffff'],
             [["a", ["b" => "c"]], '826161bf61626163ff'],
             [["Fun" => true, "Amt" => -2], 'bf6346756ef563416d7421ff'],
+        ]);
+    }
+
+    /**
+     * These are numbers in the big yellow box in pack()'s documentation
+     */
+    public function rfcBigintExamples(): array
+    {
+        return array_map(function ($vector) {
+            return [hex2bin($vector[1]), $vector[0]];
+        }, [
+            ['18446744073709551615', '1bffffffffffffffff'],
+            ['-18446744073709551616', '3bffffffffffffffff'],
+        ]);
+    }
+
+    public function rfcTagExamples(): array
+    {
+        return array_map(function ($vector) {
+            return [hex2bin($vector[1]), $vector[0]];
+        }, [
+            [18446744073709551616, 'c249010000000000000000'],
+            [-18446744073709551617, 'c349010000000000000000'],
         ]);
     }
 

--- a/tests/CBOR/vectors.json
+++ b/tests/CBOR/vectors.json
@@ -1,0 +1,636 @@
+[
+  {
+    "cbor": "AA==",
+    "hex": "00",
+    "roundtrip": true,
+    "decoded": 0
+  },
+  {
+    "cbor": "AQ==",
+    "hex": "01",
+    "roundtrip": true,
+    "decoded": 1
+  },
+  {
+    "cbor": "Cg==",
+    "hex": "0a",
+    "roundtrip": true,
+    "decoded": 10
+  },
+  {
+    "cbor": "Fw==",
+    "hex": "17",
+    "roundtrip": true,
+    "decoded": 23
+  },
+  {
+    "cbor": "GBg=",
+    "hex": "1818",
+    "roundtrip": true,
+    "decoded": 24
+  },
+  {
+    "cbor": "GBk=",
+    "hex": "1819",
+    "roundtrip": true,
+    "decoded": 25
+  },
+  {
+    "cbor": "GGQ=",
+    "hex": "1864",
+    "roundtrip": true,
+    "decoded": 100
+  },
+  {
+    "cbor": "GQPo",
+    "hex": "1903e8",
+    "roundtrip": true,
+    "decoded": 1000
+  },
+  {
+    "cbor": "GgAPQkA=",
+    "hex": "1a000f4240",
+    "roundtrip": true,
+    "decoded": 1000000
+  },
+  {
+    "cbor": "GwAAAOjUpRAA",
+    "hex": "1b000000e8d4a51000",
+    "roundtrip": true,
+    "decoded": 1000000000000
+  },
+  {
+    "cbor": "G///////////",
+    "hex": "1bffffffffffffffff",
+    "roundtrip": true,
+    "decoded": 18446744073709551615
+  },
+  {
+    "cbor": "wkkBAAAAAAAAAAA=",
+    "hex": "c249010000000000000000",
+    "roundtrip": true,
+    "decoded": 18446744073709551616
+  },
+  {
+    "cbor": "O///////////",
+    "hex": "3bffffffffffffffff",
+    "roundtrip": true,
+    "decoded": -18446744073709551616
+  },
+  {
+    "cbor": "w0kBAAAAAAAAAAA=",
+    "hex": "c349010000000000000000",
+    "roundtrip": true,
+    "decoded": -18446744073709551617
+  },
+  {
+    "cbor": "IA==",
+    "hex": "20",
+    "roundtrip": true,
+    "decoded": -1
+  },
+  {
+    "cbor": "KQ==",
+    "hex": "29",
+    "roundtrip": true,
+    "decoded": -10
+  },
+  {
+    "cbor": "OGM=",
+    "hex": "3863",
+    "roundtrip": true,
+    "decoded": -100
+  },
+  {
+    "cbor": "OQPn",
+    "hex": "3903e7",
+    "roundtrip": true,
+    "decoded": -1000
+  },
+  {
+    "cbor": "+QAA",
+    "hex": "f90000",
+    "roundtrip": true,
+    "decoded": 0.0
+  },
+  {
+    "cbor": "+YAA",
+    "hex": "f98000",
+    "roundtrip": true,
+    "decoded": -0.0
+  },
+  {
+    "cbor": "+TwA",
+    "hex": "f93c00",
+    "roundtrip": true,
+    "decoded": 1.0
+  },
+  {
+    "cbor": "+z/xmZmZmZma",
+    "hex": "fb3ff199999999999a",
+    "roundtrip": true,
+    "decoded": 1.1
+  },
+  {
+    "cbor": "+T4A",
+    "hex": "f93e00",
+    "roundtrip": true,
+    "decoded": 1.5
+  },
+  {
+    "cbor": "+Xv/",
+    "hex": "f97bff",
+    "roundtrip": true,
+    "decoded": 65504.0
+  },
+  {
+    "cbor": "+kfDUAA=",
+    "hex": "fa47c35000",
+    "roundtrip": true,
+    "decoded": 100000.0
+  },
+  {
+    "cbor": "+n9///8=",
+    "hex": "fa7f7fffff",
+    "roundtrip": true,
+    "decoded": 3.4028234663852886e+38
+  },
+  {
+    "cbor": "+3435DyIAHWc",
+    "hex": "fb7e37e43c8800759c",
+    "roundtrip": true,
+    "decoded": 1.0e+300
+  },
+  {
+    "cbor": "+QAB",
+    "hex": "f90001",
+    "roundtrip": true,
+    "decoded": 5.960464477539063e-08
+  },
+  {
+    "cbor": "+QQA",
+    "hex": "f90400",
+    "roundtrip": true,
+    "decoded": 6.103515625e-05
+  },
+  {
+    "cbor": "+cQA",
+    "hex": "f9c400",
+    "roundtrip": true,
+    "decoded": -4.0
+  },
+  {
+    "cbor": "+8AQZmZmZmZm",
+    "hex": "fbc010666666666666",
+    "roundtrip": true,
+    "decoded": -4.1
+  },
+  {
+    "cbor": "+XwA",
+    "hex": "f97c00",
+    "roundtrip": true,
+    "diagnostic": "Infinity"
+  },
+  {
+    "cbor": "+X4A",
+    "hex": "f97e00",
+    "roundtrip": true,
+    "diagnostic": "NaN"
+  },
+  {
+    "cbor": "+fwA",
+    "hex": "f9fc00",
+    "roundtrip": true,
+    "diagnostic": "-Infinity"
+  },
+  {
+    "cbor": "+n+AAAA=",
+    "hex": "fa7f800000",
+    "roundtrip": false,
+    "diagnostic": "Infinity"
+  },
+  {
+    "cbor": "+n/AAAA=",
+    "hex": "fa7fc00000",
+    "roundtrip": false,
+    "diagnostic": "NaN"
+  },
+  {
+    "cbor": "+v+AAAA=",
+    "hex": "faff800000",
+    "roundtrip": false,
+    "diagnostic": "-Infinity"
+  },
+  {
+    "cbor": "+3/wAAAAAAAA",
+    "hex": "fb7ff0000000000000",
+    "roundtrip": false,
+    "diagnostic": "Infinity"
+  },
+  {
+    "cbor": "+3/4AAAAAAAA",
+    "hex": "fb7ff8000000000000",
+    "roundtrip": false,
+    "diagnostic": "NaN"
+  },
+  {
+    "cbor": "+//wAAAAAAAA",
+    "hex": "fbfff0000000000000",
+    "roundtrip": false,
+    "diagnostic": "-Infinity"
+  },
+  {
+    "cbor": "9A==",
+    "hex": "f4",
+    "roundtrip": true,
+    "decoded": false
+  },
+  {
+    "cbor": "9Q==",
+    "hex": "f5",
+    "roundtrip": true,
+    "decoded": true
+  },
+  {
+    "cbor": "9g==",
+    "hex": "f6",
+    "roundtrip": true,
+    "decoded": null
+  },
+  {
+    "cbor": "9w==",
+    "hex": "f7",
+    "roundtrip": true,
+    "diagnostic": "undefined"
+  },
+  {
+    "cbor": "8A==",
+    "hex": "f0",
+    "roundtrip": true,
+    "diagnostic": "simple(16)"
+  },
+  {
+    "cbor": "+Bg=",
+    "hex": "f818",
+    "roundtrip": true,
+    "diagnostic": "simple(24)"
+  },
+  {
+    "cbor": "+P8=",
+    "hex": "f8ff",
+    "roundtrip": true,
+    "diagnostic": "simple(255)"
+  },
+  {
+    "cbor": "wHQyMDEzLTAzLTIxVDIwOjA0OjAwWg==",
+    "hex": "c074323031332d30332d32315432303a30343a30305a",
+    "roundtrip": true,
+    "diagnostic": "0(\"2013-03-21T20:04:00Z\")"
+  },
+  {
+    "cbor": "wRpRS2ew",
+    "hex": "c11a514b67b0",
+    "roundtrip": true,
+    "diagnostic": "1(1363896240)"
+  },
+  {
+    "cbor": "wftB1FLZ7CAAAA==",
+    "hex": "c1fb41d452d9ec200000",
+    "roundtrip": true,
+    "diagnostic": "1(1363896240.5)"
+  },
+  {
+    "cbor": "10QBAgME",
+    "hex": "d74401020304",
+    "roundtrip": true,
+    "diagnostic": "23(h'01020304')"
+  },
+  {
+    "cbor": "2BhFZElFVEY=",
+    "hex": "d818456449455446",
+    "roundtrip": true,
+    "diagnostic": "24(h'6449455446')"
+  },
+  {
+    "cbor": "2CB2aHR0cDovL3d3dy5leGFtcGxlLmNvbQ==",
+    "hex": "d82076687474703a2f2f7777772e6578616d706c652e636f6d",
+    "roundtrip": true,
+    "diagnostic": "32(\"http://www.example.com\")"
+  },
+  {
+    "cbor": "QA==",
+    "hex": "40",
+    "roundtrip": true,
+    "diagnostic": "h''"
+  },
+  {
+    "cbor": "RAECAwQ=",
+    "hex": "4401020304",
+    "roundtrip": true,
+    "diagnostic": "h'01020304'"
+  },
+  {
+    "cbor": "YA==",
+    "hex": "60",
+    "roundtrip": true,
+    "decoded": ""
+  },
+  {
+    "cbor": "YWE=",
+    "hex": "6161",
+    "roundtrip": true,
+    "decoded": "a"
+  },
+  {
+    "cbor": "ZElFVEY=",
+    "hex": "6449455446",
+    "roundtrip": true,
+    "decoded": "IETF"
+  },
+  {
+    "cbor": "YiJc",
+    "hex": "62225c",
+    "roundtrip": true,
+    "decoded": "\"\\"
+  },
+  {
+    "cbor": "YsO8",
+    "hex": "62c3bc",
+    "roundtrip": true,
+    "decoded": "ü"
+  },
+  {
+    "cbor": "Y+awtA==",
+    "hex": "63e6b0b4",
+    "roundtrip": true,
+    "decoded": "水"
+  },
+  {
+    "cbor": "ZPCQhZE=",
+    "hex": "64f0908591",
+    "roundtrip": true,
+    "decoded": "𐅑"
+  },
+  {
+    "cbor": "gA==",
+    "hex": "80",
+    "roundtrip": true,
+    "decoded": [
+
+    ]
+  },
+  {
+    "cbor": "gwECAw==",
+    "hex": "83010203",
+    "roundtrip": true,
+    "decoded": [
+      1,
+      2,
+      3
+    ]
+  },
+  {
+    "cbor": "gwGCAgOCBAU=",
+    "hex": "8301820203820405",
+    "roundtrip": true,
+    "decoded": [
+      1,
+      [
+        2,
+        3
+      ],
+      [
+        4,
+        5
+      ]
+    ]
+  },
+  {
+    "cbor": "mBkBAgMEBQYHCAkKCwwNDg8QERITFBUWFxgYGBk=",
+    "hex": "98190102030405060708090a0b0c0d0e0f101112131415161718181819",
+    "roundtrip": true,
+    "decoded": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15,
+      16,
+      17,
+      18,
+      19,
+      20,
+      21,
+      22,
+      23,
+      24,
+      25
+    ]
+  },
+  {
+    "cbor": "oA==",
+    "hex": "a0",
+    "roundtrip": true,
+    "decoded": {
+    }
+  },
+  {
+    "cbor": "ogECAwQ=",
+    "hex": "a201020304",
+    "roundtrip": true,
+    "diagnostic": "{1: 2, 3: 4}"
+  },
+  {
+    "cbor": "omFhAWFiggID",
+    "hex": "a26161016162820203",
+    "roundtrip": true,
+    "decoded": {
+      "a": 1,
+      "b": [
+        2,
+        3
+      ]
+    }
+  },
+  {
+    "cbor": "gmFhoWFiYWM=",
+    "hex": "826161a161626163",
+    "roundtrip": true,
+    "decoded": [
+      "a",
+      {
+        "b": "c"
+      }
+    ]
+  },
+  {
+    "cbor": "pWFhYUFhYmFCYWNhQ2FkYURhZWFF",
+    "hex": "a56161614161626142616361436164614461656145",
+    "roundtrip": true,
+    "decoded": {
+      "a": "A",
+      "b": "B",
+      "c": "C",
+      "d": "D",
+      "e": "E"
+    }
+  },
+  {
+    "cbor": "X0IBAkMDBAX/",
+    "hex": "5f42010243030405ff",
+    "roundtrip": false,
+    "diagnostic": "(_ h'0102', h'030405')"
+  },
+  {
+    "cbor": "f2VzdHJlYWRtaW5n/w==",
+    "hex": "7f657374726561646d696e67ff",
+    "roundtrip": false,
+    "decoded": "streaming"
+  },
+  {
+    "cbor": "n/8=",
+    "hex": "9fff",
+    "roundtrip": false,
+    "decoded": [
+
+    ]
+  },
+  {
+    "cbor": "nwGCAgOfBAX//w==",
+    "hex": "9f018202039f0405ffff",
+    "roundtrip": false,
+    "decoded": [
+      1,
+      [
+        2,
+        3
+      ],
+      [
+        4,
+        5
+      ]
+    ]
+  },
+  {
+    "cbor": "nwGCAgOCBAX/",
+    "hex": "9f01820203820405ff",
+    "roundtrip": false,
+    "decoded": [
+      1,
+      [
+        2,
+        3
+      ],
+      [
+        4,
+        5
+      ]
+    ]
+  },
+  {
+    "cbor": "gwGCAgOfBAX/",
+    "hex": "83018202039f0405ff",
+    "roundtrip": false,
+    "decoded": [
+      1,
+      [
+        2,
+        3
+      ],
+      [
+        4,
+        5
+      ]
+    ]
+  },
+  {
+    "cbor": "gwGfAgP/ggQF",
+    "hex": "83019f0203ff820405",
+    "roundtrip": false,
+    "decoded": [
+      1,
+      [
+        2,
+        3
+      ],
+      [
+        4,
+        5
+      ]
+    ]
+  },
+  {
+    "cbor": "nwECAwQFBgcICQoLDA0ODxAREhMUFRYXGBgYGf8=",
+    "hex": "9f0102030405060708090a0b0c0d0e0f101112131415161718181819ff",
+    "roundtrip": false,
+    "decoded": [
+      1,
+      2,
+      3,
+      4,
+      5,
+      6,
+      7,
+      8,
+      9,
+      10,
+      11,
+      12,
+      13,
+      14,
+      15,
+      16,
+      17,
+      18,
+      19,
+      20,
+      21,
+      22,
+      23,
+      24,
+      25
+    ]
+  },
+  {
+    "cbor": "v2FhAWFinwID//8=",
+    "hex": "bf61610161629f0203ffff",
+    "roundtrip": false,
+    "decoded": {
+      "a": 1,
+      "b": [
+        2,
+        3
+      ]
+    }
+  },
+  {
+    "cbor": "gmFhv2FiYWP/",
+    "hex": "826161bf61626163ff",
+    "roundtrip": false,
+    "decoded": [
+      "a",
+      {
+        "b": "c"
+      }
+    ]
+  },
+  {
+    "cbor": "v2NGdW71Y0FtdCH/",
+    "hex": "bf6346756ef563416d7421ff",
+    "roundtrip": false,
+    "decoded": {
+      "Fun": true,
+      "Amt": -2
+    }
+  }
+]


### PR DESCRIPTION
Closes #2, closes #1

For the most part, this is just a tremendous amount of format shifting, and some updated demo code which should get migrated to Firehed/u2f-php-examples. As far as I can tell, this shouldn't be a breaking change, though I think it still constitutes a 2.0 release as it packages a lot of new functionality.

Right now, this needs the following changes:

- [ ] Move CBOR decoder into separate repo (unfortunately I found some minor compatibility issues with the existing ones) and add it as a dependency
- [ ] Rename the additional WebAuthn-specific data structures
- [ ] Encapsulate the "demo" parsing logic of client requests (the POSTed JSON structure will need to be documented)
- [ ] Examine the adjustments in the `Server` code to ensure no weird cross-origin/Relying Party issues are exposed
- [ ] Resolve the issue where WebAuthn expects a single challenge across all registered keys, where the old format did not
- [ ] Test in Chrome
- [ ] Move (or consolidate) the demo code
- [ ] Look at tidying up classes/interfaces for reused objects (will probably close #4)

Also, it would be worth considering other formats and verification procedures, though that's out of scope for now (basically the entirety of WebAuthn section 8)