### PR TITLE
Add interfaces for data structures

### DIFF
--- a/src/AppIdTrait.php
+++ b/src/AppIdTrait.php
@@ -25,4 +25,12 @@ trait AppIdTrait
     {
         return hash('sha256', $this->appId, true);
     }
+
+    /**
+     * @return string The raw SHA-256 hash of the Relying Party ID
+     */
+    public function getRpIdHash(): string
+    {
+        return hash('sha256', $this->appId, true);
+    }
 }

--- a/src/AttestationCertificateTrait.php
+++ b/src/AttestationCertificateTrait.php
@@ -31,17 +31,4 @@ trait AttestationCertificateTrait
         $this->attest = $cert;
         return $this;
     }
-
-    public function verifyIssuerAgainstTrustedCAs(array $trusted_cas): bool
-    {
-        $result = openssl_x509_checkpurpose(
-            $this->getAttestationCertificatePem(),
-            \X509_PURPOSE_ANY,
-            $trusted_cas
-        );
-        if ($result !== true) {
-            throw new SecurityException(SecurityException::NO_TRUSTED_CA);
-        }
-        return $result;
-    }
 }

--- a/src/ChallengeProvider.php
+++ b/src/ChallengeProvider.php
@@ -5,6 +5,5 @@ namespace Firehed\U2F;
 
 interface ChallengeProvider
 {
-
     public function getChallenge(): string;
 }

--- a/src/ClientData.php
+++ b/src/ClientData.php
@@ -28,6 +28,11 @@ class ClientData implements JsonSerializable, ChallengeProvider
         return $ret;
     }
 
+    public function getApplicationParameter(): string
+    {
+        return hash('sha256', $this->origin, true);
+    }
+
     /**
      * Checks the 'typ' field against the allowed types in the U2F spec (sec.
      * 7.1)

--- a/src/LoginResponseInterface.php
+++ b/src/LoginResponseInterface.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace Firehed\U2F;
+
+interface LoginResponseInterface
+{
+    public function getChallengeProvider(): ChallengeProvider;
+
+    public function getCounter(): int;
+
+    public function getKeyHandleBinary(): string;
+
+    public function getSignature(): string;
+
+    public function getSignedData(): string;
+}

--- a/src/RegisterResponse.php
+++ b/src/RegisterResponse.php
@@ -5,7 +5,7 @@ namespace Firehed\U2F;
 
 use Firehed\U2F\InvalidDataException as IDE;
 
-class RegisterResponse
+class RegisterResponse implements RegistrationResponseInterface
 {
     use AttestationCertificateTrait;
     use ECPublicKeyTrait;
@@ -107,5 +107,23 @@ class RegisterResponse
         $this->setSignature(substr($regData, $offset));
 
         return $this;
+    }
+
+    public function getSignedData(): string
+    {
+        // https://fidoalliance.org/specs/fido-u2f-v1.0-nfc-bt-amendment-20150514/fido-u2f-raw-message-formats.html#fig-authentication-request-message
+        return sprintf(
+            '%s%s%s%s%s',
+            chr(0),
+            $this->getClientData()->getApplicationParameter(),
+            $this->getClientData()->getChallengeParameter(),
+            $this->getKeyHandleBinary(),
+            $this->getPublicKeyBinary()
+        );
+    }
+
+    public function getRpIdHash(): string
+    {
+        return $this->getClientData()->getApplicationParameter();
     }
 }

--- a/src/RegistrationResponseInterface.php
+++ b/src/RegistrationResponseInterface.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace Firehed\U2F;
+
+interface RegistrationResponseInterface
+{
+    public function getAttestationCertificateBinary(): string;
+
+    public function getAttestationCertificatePem(): string;
+
+    public function getChallengeProvider(): ChallengeProvider;
+
+    public function getKeyHandleBinary(): string;
+
+    public function getPublicKeyBinary(): string;
+
+    public function getRpIdHash(): string;
+
+    public function getSignature(): string;
+
+    public function getSignedData(): string;
+
+    public function verifyIssuerAgainstTrustedCAs(array $trustedCAs): bool;
+}

--- a/src/RegistrationResponseInterface.php
+++ b/src/RegistrationResponseInterface.php
@@ -20,6 +20,4 @@ interface RegistrationResponseInterface
     public function getSignature(): string;
 
     public function getSignedData(): string;
-
-    public function verifyIssuerAgainstTrustedCAs(array $trustedCAs): bool;
 }

--- a/src/ResponseTrait.php
+++ b/src/ResponseTrait.php
@@ -24,6 +24,11 @@ trait ResponseTrait
         return $this->clientData;
     }
 
+    public function getChallengeProvider(): ChallengeProvider
+    {
+        return $this->clientData;
+    }
+
     protected function setSignature(string $signature): self
     {
         $this->signature = $signature;

--- a/src/SecurityException.php
+++ b/src/SecurityException.php
@@ -12,6 +12,7 @@ class SecurityException extends Exception
     const CHALLENGE_MISMATCH = 3;
     const KEY_HANDLE_UNRECOGNIZED = 4;
     const NO_TRUSTED_CA = 5;
+    const WRONG_RELYING_PARTY = 6;
 
     const MESSAGES = [
         self::SIGNATURE_INVALID => 'Signature verification failed',
@@ -23,6 +24,7 @@ class SecurityException extends Exception
         self::CHALLENGE_MISMATCH => 'Response challenge does not match request',
         self::KEY_HANDLE_UNRECOGNIZED => 'Key handle has not been registered',
         self::NO_TRUSTED_CA => 'The attestation certificate was not signed by any trusted Certificate Authority',
+        self::WRONG_RELYING_PARTY => 'Relying party invalid for this server',
     ];
 
     public function __construct(int $code)

--- a/src/Server.php
+++ b/src/Server.php
@@ -196,15 +196,7 @@ class Server
         }
         $this->validateChallenge($response->getChallengeProvider(), $this->registerRequest);
         // Check the Application Parameter
-        // Note: this is a bit delicate at the moment, since different
-        // protocols have different rules around the handling of Relying Party
-        // verification. Expect this to be revised.
-        if (!hash_equals(
-            $this->registerRequest->getApplicationParameter(),
-            $response->getRpIdHash()
-        )) {
-            throw new SE(SE::SIGNATURE_INVALID);
-        }
+        $this->validateRelyingParty($response->getRpIdHash());
 
         if ($this->verifyCA) {
             $this->verifyAttestationCertAgainstTrustedCAs($response);
@@ -380,6 +372,15 @@ class Server
         return toBase64Web(\random_bytes(16));
     }
 
+    private function validateRelyingParty(string $rpIdHash): void
+    {
+        // Note: this is a bit delicate at the moment, since different
+        // protocols have different rules around the handling of Relying Party
+        // verification. Expect this to be revised.
+        if (!hash_equals($this->getRpIdHash(), $rpIdHash)) {
+            throw new SE(SE::WRONG_RELYING_PARTY);
+        }
+    }
     /**
      * Compares the Challenge value from a known source against the
      * user-provided value. A mismatch will throw a SE. Future

--- a/tests/AppIdTraitTest.php
+++ b/tests/AppIdTraitTest.php
@@ -50,4 +50,21 @@ class AppIdTraitTest extends \PHPUnit\Framework\TestCase
             'getApplicationParamter should return the raw SHA256 hash of the application id'
         );
     }
+
+    /**
+     * @covers ::getRpIdHash
+     */
+    public function testGetRpIdHash()
+    {
+        $obj = new class {
+            use AppIdTrait;
+        };
+        $appId = 'https://u2f.example.com';
+        $obj->setAppId($appId);
+        $this->assertSame(
+            hash('sha256', $appId, true),
+            $obj->getRpIdHash(),
+            'getRpIdHash should return the raw SHA256 hash of the application id'
+        );
+    }
 }

--- a/tests/AttestationCertificateTraitTest.php
+++ b/tests/AttestationCertificateTraitTest.php
@@ -52,40 +52,6 @@ class AttestationCertificateTraitTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    /**
-     * @covers ::verifyIssuerAgainstTrustedCAs
-     */
-    public function testSuccessfulCAVerification()
-    {
-        $class = $this->getObjectWithYubicoCert();
-        $certs = [dirname(__DIR__).'/CAcerts/yubico.pem'];
-        $this->assertTrue($class->verifyIssuerAgainstTrustedCAs($certs));
-    }
-
-    /**
-     * @covers ::verifyIssuerAgainstTrustedCAs
-     */
-    public function testFailedCAVerification()
-    {
-        $class = $this->getObjectWithYubicoCert();
-        $certs = [__DIR__.'/verisign_only_for_unit_tests.pem'];
-        $this->expectException(SecurityException::class);
-        $this->expectExceptionCode(SecurityException::NO_TRUSTED_CA);
-        $class->verifyIssuerAgainstTrustedCAs($certs);
-    }
-
-    /**
-     * @covers ::verifyIssuerAgainstTrustedCAs
-     */
-    public function testFailedCAVerificationFromNoCAs()
-    {
-        $class = $this->getObjectWithYubicoCert();
-        $certs = [];
-        $this->expectException(SecurityException::class);
-        $this->expectExceptionCode(SecurityException::NO_TRUSTED_CA);
-        $class->verifyIssuerAgainstTrustedCAs($certs);
-    }
-
     // -(Helper methods)-------------------------------------------------------
 
     /**

--- a/tests/ClientDataTest.php
+++ b/tests/ClientDataTest.php
@@ -10,7 +10,6 @@ namespace Firehed\U2F;
  */
 class ClientDataTest extends \PHPUnit\Framework\TestCase
 {
-
     /**
      * @covers ::fromJson
      */

--- a/tests/ClientDataTest.php
+++ b/tests/ClientDataTest.php
@@ -59,6 +59,26 @@ class ClientDataTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @covers ::getApplicationParameter
+     */
+    public function testGetApplicationParameter()
+    {
+        $goodData = [
+            'typ' => 'navigator.id.finishEnrollment',
+            'challenge' => 'PfsWR1Umy2V5Al1Bam2tG0yfPLeJElfwRzzAzkYPgzo',
+            'origin' => 'https://u2f.ericstern.com',
+            'cid_pubkey' => '',
+        ];
+        $goodJson = json_encode($goodData);
+        assert($goodJson !== false);
+        $clientData = ClientData::fromJson($goodJson);
+        $this->assertSame(
+            hash('sha256', 'https://u2f.ericstern.com', true),
+            $clientData->getApplicationParameter()
+        );
+    }
+
+    /**
      * @covers ::fromJson
      */
     public function testBadJson()

--- a/tests/RegisterResponseTest.php
+++ b/tests/RegisterResponseTest.php
@@ -138,6 +138,40 @@ class RegisterResponseTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    /**
+     * @covers ::getSignedData
+     */
+    public function testGetSignedData()
+    {
+        $json = file_get_contents(__DIR__ . '/register_response.json');
+        assert($json !== false);
+        $response = RegisterResponse::fromJson($json);
+
+        $expectedSignedData = sprintf(
+            '%s%s%s%s%s',
+            "\x00",
+            hash('sha256', 'https://u2f.ericstern.com', true),
+            hash(
+                'sha256',
+                '{'.
+                '"typ":"navigator.id.finishEnrollment",'.
+                '"challenge":"PfsWR1Umy2V5Al1Bam2tG0yfPLeJElfwRzzAzkYPgzo",'.
+                '"origin":"https://u2f.ericstern.com",'.
+                '"cid_pubkey":""'.
+                '}',
+                true
+            ),
+            $response->getKeyHandleBinary(),
+            $response->getPublicKeyBinary()
+        );
+
+        $this->assertSame(
+            $expectedSignedData,
+            $response->getSignedData(),
+            'Wrong signed data'
+        );
+    }
+
     // -( DataProviders )------------------------------------------------------
 
     public function clientErrors()

--- a/tests/RegisterResponseTest.php
+++ b/tests/RegisterResponseTest.php
@@ -172,6 +172,21 @@ class RegisterResponseTest extends \PHPUnit\Framework\TestCase
         );
     }
 
+    /**
+     * @covers ::getRpIdHash
+     */
+    public function testGetRpIdHash()
+    {
+        $json = file_get_contents(__DIR__ . '/register_response.json');
+        assert($json !== false);
+        $response = RegisterResponse::fromJson($json);
+
+        $this->assertSame(
+            hash('sha256', 'https://u2f.ericstern.com', true),
+            $response->getRpIdHash()
+        );
+    }
+
     // -( DataProviders )------------------------------------------------------
 
     public function clientErrors()

--- a/tests/ResponseTraitTest.php
+++ b/tests/ResponseTraitTest.php
@@ -27,6 +27,7 @@ class ResponseTraitTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::fromJson
      * @covers ::getSignature
+     * @covers ::getChallengeProvider
      * @covers ::getClientData
      */
     public function testValidJson()
@@ -54,6 +55,11 @@ class ResponseTraitTest extends \PHPUnit\Framework\TestCase
             ClientData::class,
             $response->getClientData(),
             'ClientData was not parsed correctly'
+        );
+        $this->assertInstanceOf(
+            ChallengeProvider::class,
+            $response->getChallengeProvider(),
+            'Did not get a challenge provider'
         );
 
         $this->assertSame(

--- a/tests/SignResponseTest.php
+++ b/tests/SignResponseTest.php
@@ -181,6 +181,40 @@ class SignResponseTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @covers ::getSignedData
+     */
+    public function testGetSignedData()
+    {
+        $json = file_get_contents(__DIR__ . '/sign_response.json');
+        assert($json !== false);
+        $response = SignResponse::fromJson($json);
+        print_r($response);
+
+        $expectedSignedData = sprintf(
+            '%s%s%s%s',
+            hash('sha256', 'https://u2f.ericstern.com', true),
+            "\x01", // user presence
+            "\x00\x00\x00\x2d", // counter (int(45))
+            hash(
+                'sha256',
+                '{'.
+                '"typ":"navigator.id.getAssertion",'.
+                '"challenge":"wt2ze8IskcTO3nIsO2D2hFjE5tVD041NpnYesLpJweg",'.
+                '"origin":"https://u2f.ericstern.com",'.
+                '"cid_pubkey":""'.
+                '}',
+                true
+            ),
+        );
+
+        $this->assertSame(
+            $expectedSignedData,
+            $response->getSignedData(),
+            'Wrong signed data'
+        );
+    }
+
+    /**
      * @dataProvider clientErrors
      */
     public function testErrorResponse(int $code)

--- a/tests/SignResponseTest.php
+++ b/tests/SignResponseTest.php
@@ -204,7 +204,7 @@ class SignResponseTest extends \PHPUnit\Framework\TestCase
                 '"cid_pubkey":""'.
                 '}',
                 true
-            ),
+            )
         );
 
         $this->assertSame(

--- a/tests/SignResponseTest.php
+++ b/tests/SignResponseTest.php
@@ -188,7 +188,6 @@ class SignResponseTest extends \PHPUnit\Framework\TestCase
         $json = file_get_contents(__DIR__ . '/sign_response.json');
         assert($json !== false);
         $response = SignResponse::fromJson($json);
-        print_r($response);
 
         $expectedSignedData = sprintf(
             '%s%s%s%s',


### PR DESCRIPTION
Work on #4 

The request side still needs a bit of work, but this decouples the response handling of the server from specific formats and changes the focus to be the high-level procedure.

Most notably, the "what data should have been signed?" shifts into the response structures, which not only is critical for basic WebAuthn support (#2), but potentially other attestation formats.

This may be adjusted slightly before the 2.0 tag.