### PR TITLE
Remove ChallengeProvider interface

### DIFF
--- a/src/ClientData.php
+++ b/src/ClientData.php
@@ -6,7 +6,7 @@ namespace Firehed\U2F;
 use JsonSerializable;
 use Firehed\U2F\InvalidDataException as IDE;
 
-class ClientData implements JsonSerializable, ChallengeProvider
+class ClientData implements JsonSerializable
 {
     use ChallengeTrait;
 

--- a/src/LoginResponseInterface.php
+++ b/src/LoginResponseInterface.php
@@ -3,10 +3,8 @@ declare(strict_types=1);
 
 namespace Firehed\U2F;
 
-interface LoginResponseInterface
+interface LoginResponseInterface extends ChallengeProvider
 {
-    public function getChallengeProvider(): ChallengeProvider;
-
     public function getCounter(): int;
 
     public function getKeyHandleBinary(): string;

--- a/src/RegisterResponse.php
+++ b/src/RegisterResponse.php
@@ -137,6 +137,11 @@ class RegisterResponse implements RegistrationResponseInterface
         return $this->cert;
     }
 
+    public function getChallenge(): string
+    {
+        return $this->clientData->getChallenge();
+    }
+
     public function getPublicKey(): PublicKeyInterface
     {
         return $this->pubKey;

--- a/src/RegistrationResponseInterface.php
+++ b/src/RegistrationResponseInterface.php
@@ -3,11 +3,9 @@ declare(strict_types=1);
 
 namespace Firehed\U2F;
 
-interface RegistrationResponseInterface
+interface RegistrationResponseInterface extends ChallengeProvider
 {
     public function getAttestationCertificate(): AttestationCertificate;
-
-    public function getChallengeProvider(): ChallengeProvider;
 
     public function getKeyHandleBinary(): string;
 

--- a/src/ResponseTrait.php
+++ b/src/ResponseTrait.php
@@ -20,11 +20,6 @@ trait ResponseTrait
         return $this->signature;
     }
 
-    public function getChallengeProvider(): ChallengeProvider
-    {
-        return $this->clientData;
-    }
-
     protected function setSignature(string $signature): self
     {
         $this->signature = $signature;

--- a/src/Server.php
+++ b/src/Server.php
@@ -118,7 +118,7 @@ class Server
         // match the one in the signing request, the client signed the
         // wrong thing. This could possibly be an attempt at a replay
         // attack.
-        $this->validateChallenge($response->getChallengeProvider(), $request);
+        $this->validateChallenge($request, $response);
 
         $pem = $registration->getPublicKey()->getPemFormatted();
 
@@ -195,7 +195,7 @@ class Server
                 'with setRegisterRequest()'
             );
         }
-        $this->validateChallenge($response->getChallengeProvider(), $this->registerRequest);
+        $this->validateChallenge($this->registerRequest, $response);
         // Check the Application Parameter
         $this->validateRelyingParty($response->getRpIdHash());
 
@@ -389,13 +389,10 @@ class Server
      *
      * @param ChallengeProvider $from source of known challenge
      * @param ChallengeProvider $to user-provided value
-     * @return true on success
      * @throws SE on failure
      */
-    private function validateChallenge(
-        ChallengeProvider $from,
-        ChallengeProvider $to
-    ): bool {
+    private function validateChallenge(ChallengeProvider $from, ChallengeProvider $to)
+    {
         // Note: strictly speaking, this shouldn't even be targetable as
         // a timing attack. However, this opts to be proactive, and also
         // ensures that no weird PHP-isms in string handling cause mismatched
@@ -403,8 +400,6 @@ class Server
         if (!hash_equals($from->getChallenge(), $to->getChallenge())) {
             throw new SE(SE::CHALLENGE_MISMATCH);
         }
-        // TOOD: generate and compare timestamps
-        return true;
     }
 
     /**

--- a/src/SignResponse.php
+++ b/src/SignResponse.php
@@ -61,4 +61,9 @@ class SignResponse implements LoginResponseInterface
         $this->setSignature($decoded['signature']);
         return $this;
     }
+
+    public function getChallenge(): string
+    {
+        return $this->clientData->getChallenge();
+    }
 }

--- a/tests/RegisterResponseTest.php
+++ b/tests/RegisterResponseTest.php
@@ -173,6 +173,20 @@ class RegisterResponseTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @covers ::getChallenge
+     */
+    public function testGetChallenge()
+    {
+        $json = file_get_contents(__DIR__ . '/register_response.json');
+        assert($json !== false);
+        $response = RegisterResponse::fromJson($json);
+
+        $this->assertSame(
+            'PfsWR1Umy2V5Al1Bam2tG0yfPLeJElfwRzzAzkYPgzo',
+            $response->getChallenge()
+        );
+    }
+    /**
      * @covers ::getRpIdHash
      */
     public function testGetRpIdHash()

--- a/tests/ResponseTraitTest.php
+++ b/tests/ResponseTraitTest.php
@@ -27,7 +27,6 @@ class ResponseTraitTest extends \PHPUnit\Framework\TestCase
     /**
      * @covers ::fromJson
      * @covers ::getSignature
-     * @covers ::getChallengeProvider
      */
     public function testValidJson()
     {
@@ -48,12 +47,6 @@ class ResponseTraitTest extends \PHPUnit\Framework\TestCase
             get_class($this->trait),
             $response,
             'Parsed response was the wrong type'
-        );
-
-        $this->assertInstanceOf(
-            ChallengeProvider::class,
-            $response->getChallengeProvider(),
-            'Did not get a challenge provider'
         );
 
         $this->assertSame(

--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -328,12 +328,9 @@ class ServerTest extends \PHPUnit\Framework\TestCase
     {
         $request = $this->getDefaultRegisterRequest();
 
-        $challengeProvider = $this->createMock(ChallengeProvider::class);
-        $challengeProvider->method('getChallenge')
-            ->willReturn($request->getChallenge());
         $response = $this->createMock(RegistrationResponseInterface::class);
-        $response->method('getChallengeProvider')
-            ->willReturn($challengeProvider);
+        $response->method('getChallenge')
+            ->willReturn($request->getChallenge());
         $response->method('getRpIdHash')
             ->willReturn(hash('sha256', 'https://some.otherdomain.com', true));
 

--- a/tests/SignResponseTest.php
+++ b/tests/SignResponseTest.php
@@ -214,6 +214,21 @@ class SignResponseTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * @covers ::getChallenge
+     */
+    public function testGetChallenge()
+    {
+        $json = file_get_contents(__DIR__ . '/sign_response.json');
+        assert($json !== false);
+        $response = SignResponse::fromJson($json);
+
+        $this->assertSame(
+            'wt2ze8IskcTO3nIsO2D2hFjE5tVD041NpnYesLpJweg',
+            $response->getChallenge()
+        );
+    }
+
+    /**
      * @dataProvider clientErrors
      */
     public function testErrorResponse(int $code)


### PR DESCRIPTION
Since the internals of the `Server` have been updated and interfaces for the data structures have solidified, the `ChallengeProvider` has become redundant. This removes it, in favor of using `getChallenge()` directly.