### PR TITLE
Replace Server test data with controlled mocks

### DIFF
--- a/tests/ServerTest.php
+++ b/tests/ServerTest.php
@@ -794,7 +794,7 @@ class ServerTest extends \PHPUnit\Framework\TestCase
             hash('sha256', 'https://u2f.ericstern.com', true),
             chr(1),
             pack('N', 45),
-            hash('sha256', $challengeParamaeterJson, true),
+            hash('sha256', $challengeParamaeterJson, true)
         ));
 
         return $mock;


### PR DESCRIPTION
This is laying groundwork for the deprecation and removal of the U2F-specific legacy formats.